### PR TITLE
enable syslog so ossec can pick up events

### DIFF
--- a/templates/etc/suricata/suricata.yaml.j2
+++ b/templates/etc/suricata/suricata.yaml.j2
@@ -88,9 +88,9 @@ outputs:
       type: syslog #file|syslog|unix_dgram|unix_stream
       filename: eve.json
       # the following are valid when type: syslog above
-      #identity: "suricata"
-      #facility: local5
-      #level: Info ## possible levels: Emergency, Alert, Critical,
+      identity: "suricata"
+      facility: local5
+      level: Info ## possible levels: Emergency, Alert, Critical,
                    ## Error, Warning, Notice, Info, Debug
       types:
         - alert


### PR DESCRIPTION
suricata currently logs to a file which does not leave the NAT instance's local disk. This will not survive a server rebuild. This also will not forward logs to the elasticsearch ossec index since it is not sending to the local rsyslog, which is what is configured to forward to the ossec server.

Enable logging to a syslog facility in the suricata config.